### PR TITLE
Range casting to array code example fixed (#311)

### DIFF
--- a/syntax_and_semantics/literals/range.md
+++ b/syntax_and_semantics/literals/range.md
@@ -7,8 +7,8 @@ x..y  # an inclusive range, in mathematics: [x, y]
 x...y # an exclusive range, in mathematics: [x, y)
 
 # Example:
-0..5.to_a # => [0, 1, 2, 3, 4, 5]
-0...5.to_a # => [0, 1, 2, 3, 4]
+(0..5).to_a # => [0, 1, 2, 3, 4, 5]
+(0...5).to_a # => [0, 1, 2, 3, 4]
 ```
 
 An easy way to remember which one is inclusive and which one is exclusive it to think of the extra dot as if it pushes *y* further away, thus leaving it outside of the range.


### PR DESCRIPTION
There should be parentheses around the range before casting, because in this way, we try to cast the 5 not the whole range